### PR TITLE
feat: Implement Notification Service - Port 8088

### DIFF
--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -66,6 +66,14 @@ spring:
           filters:
             - Jwt
 
+        # Notification Service: /api/notifications/** -> localhost:8088/api/notifications/**
+        - id: notification-service
+          uri: http://localhost:8088
+          predicates:
+            - Path=/api/notifications/**
+          filters:
+            - Jwt
+
 management:
   endpoints:
     web:

--- a/backend/notification-service/Dockerfile
+++ b/backend/notification-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8088
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/notification-service/pom.xml
+++ b/backend/notification-service/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.decp</groupId>
+        <artifactId>decp-backend</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>notification-service</artifactId>
+    <name>Notification Service</name>
+    <description>Notification Service for DECP</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/notification-service/src/main/java/com/decp/notification/NotificationServiceApplication.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/NotificationServiceApplication.java
@@ -1,0 +1,11 @@
+package com.decp.notification;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class NotificationServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(NotificationServiceApplication.class, args);
+    }
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/config/RabbitMQConfig.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/config/RabbitMQConfig.java
@@ -1,0 +1,138 @@
+package com.decp.notification.config;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    // Exchanges (matching what publisher services declare)
+    public static final String USER_EXCHANGE = "user.exchange";
+    public static final String POST_EXCHANGE = "post.exchange";
+    public static final String EVENT_EXCHANGE = "event-exchange";
+    public static final String JOB_EXCHANGE = "job.exchange";
+
+    // Queues for notification service
+    public static final String USER_REGISTERED_QUEUE = "notification.user.registered";
+    public static final String POST_CREATED_QUEUE = "notification.post.created";
+    public static final String POST_LIKED_QUEUE = "notification.post.liked";
+    public static final String POST_COMMENTED_QUEUE = "notification.post.commented";
+    public static final String JOB_CREATED_QUEUE = "notification.job.created";
+    public static final String JOB_APPLIED_QUEUE = "notification.job.applied";
+    public static final String EVENT_CREATED_QUEUE = "notification.event.created";
+    public static final String EVENT_RSVP_QUEUE = "notification.event.rsvp";
+
+    // Exchanges
+    @Bean
+    public TopicExchange userExchange() {
+        return new TopicExchange(USER_EXCHANGE);
+    }
+
+    @Bean
+    public TopicExchange postExchange() {
+        return new TopicExchange(POST_EXCHANGE);
+    }
+
+    @Bean
+    public TopicExchange eventExchange() {
+        return new TopicExchange(EVENT_EXCHANGE);
+    }
+
+    @Bean
+    public TopicExchange jobExchange() {
+        return new TopicExchange(JOB_EXCHANGE);
+    }
+
+    // Queues
+    @Bean
+    public Queue userRegisteredQueue() {
+        return new Queue(USER_REGISTERED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue postCreatedQueue() {
+        return new Queue(POST_CREATED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue postLikedQueue() {
+        return new Queue(POST_LIKED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue postCommentedQueue() {
+        return new Queue(POST_COMMENTED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue jobCreatedQueue() {
+        return new Queue(JOB_CREATED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue jobAppliedQueue() {
+        return new Queue(JOB_APPLIED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue eventCreatedQueue() {
+        return new Queue(EVENT_CREATED_QUEUE, true);
+    }
+
+    @Bean
+    public Queue eventRsvpQueue() {
+        return new Queue(EVENT_RSVP_QUEUE, true);
+    }
+
+    // Bindings
+    @Bean
+    public Binding userRegisteredBinding(Queue userRegisteredQueue, TopicExchange userExchange) {
+        return BindingBuilder.bind(userRegisteredQueue).to(userExchange).with("user.registered");
+    }
+
+    @Bean
+    public Binding postCreatedBinding(Queue postCreatedQueue, TopicExchange postExchange) {
+        return BindingBuilder.bind(postCreatedQueue).to(postExchange).with("post.created");
+    }
+
+    @Bean
+    public Binding postLikedBinding(Queue postLikedQueue, TopicExchange postExchange) {
+        return BindingBuilder.bind(postLikedQueue).to(postExchange).with("post.liked");
+    }
+
+    @Bean
+    public Binding postCommentedBinding(Queue postCommentedQueue, TopicExchange postExchange) {
+        return BindingBuilder.bind(postCommentedQueue).to(postExchange).with("post.commented");
+    }
+
+    @Bean
+    public Binding jobCreatedBinding(Queue jobCreatedQueue, TopicExchange jobExchange) {
+        return BindingBuilder.bind(jobCreatedQueue).to(jobExchange).with("job.created");
+    }
+
+    @Bean
+    public Binding jobAppliedBinding(Queue jobAppliedQueue, TopicExchange jobExchange) {
+        return BindingBuilder.bind(jobAppliedQueue).to(jobExchange).with("job.applied");
+    }
+
+    @Bean
+    public Binding eventCreatedBinding(Queue eventCreatedQueue, TopicExchange eventExchange) {
+        return BindingBuilder.bind(eventCreatedQueue).to(eventExchange).with("event.created");
+    }
+
+    @Bean
+    public Binding eventRsvpBinding(Queue eventRsvpQueue, TopicExchange eventExchange) {
+        return BindingBuilder.bind(eventRsvpQueue).to(eventExchange).with("event.rsvp");
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/controller/NotificationController.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/controller/NotificationController.java
@@ -1,0 +1,53 @@
+package com.decp.notification.controller;
+
+import com.decp.notification.dto.NotificationResponse;
+import com.decp.notification.dto.UnreadCountResponse;
+import com.decp.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> getUserNotifications(
+            @RequestHeader("X-User-Name") String userName) {
+        return ResponseEntity.ok(notificationService.getUserNotifications(userName));
+    }
+
+    @PutMapping("/{id}/read")
+    public ResponseEntity<NotificationResponse> markAsRead(
+            @PathVariable String id,
+            @RequestHeader("X-User-Name") String userName) {
+        return ResponseEntity.ok(notificationService.markAsRead(id, userName));
+    }
+
+    @PutMapping("/read-all")
+    public ResponseEntity<Void> markAllAsRead(
+            @RequestHeader("X-User-Name") String userName) {
+        notificationService.markAllAsRead(userName);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/unread-count")
+    public ResponseEntity<UnreadCountResponse> getUnreadCount(
+            @RequestHeader("X-User-Name") String userName) {
+        long count = notificationService.getUnreadCount(userName);
+        return ResponseEntity.ok(new UnreadCountResponse(count));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteNotification(
+            @PathVariable String id,
+            @RequestHeader("X-User-Name") String userName) {
+        notificationService.deleteNotification(id, userName);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/dto/NotificationResponse.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/dto/NotificationResponse.java
@@ -1,0 +1,26 @@
+package com.decp.notification.dto;
+
+import com.decp.notification.model.NotificationType;
+import com.decp.notification.model.ReferenceType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponse {
+    private String id;
+    private String userId;
+    private NotificationType type;
+    private String title;
+    private String message;
+    private String referenceId;
+    private ReferenceType referenceType;
+    private boolean read;
+    private LocalDateTime createdAt;
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/dto/UnreadCountResponse.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/dto/UnreadCountResponse.java
@@ -1,0 +1,14 @@
+package com.decp.notification.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UnreadCountResponse {
+    private long count;
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/exception/GlobalExceptionHandler.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.decp.notification.exception;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("message", ex.getMessage());
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        if (ex.getMessage() != null) {
+            if (ex.getMessage().contains("not found")) {
+                status = HttpStatus.NOT_FOUND;
+            } else if (ex.getMessage().contains("Not authorized")) {
+                status = HttpStatus.FORBIDDEN;
+            }
+        }
+
+        body.put("status", status.value());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+        body.put("errors", errors);
+
+        return ResponseEntity.badRequest().body(body);
+    }
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/listener/NotificationListener.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/listener/NotificationListener.java
@@ -1,0 +1,203 @@
+package com.decp.notification.listener;
+
+import com.decp.notification.config.RabbitMQConfig;
+import com.decp.notification.model.NotificationType;
+import com.decp.notification.model.ReferenceType;
+import com.decp.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class NotificationListener {
+
+    private final NotificationService notificationService;
+
+    @RabbitListener(queues = RabbitMQConfig.USER_REGISTERED_QUEUE)
+    public void handleUserRegistered(Object message) {
+        try {
+            String userId = extractString(message);
+            log.info("Received user.registered event for userId: {}", userId);
+            notificationService.createNotification(
+                    userId,
+                    NotificationType.USER_REGISTERED,
+                    "Welcome to DECP!",
+                    "Welcome to the Department Engagement & Career Platform. Start by completing your profile.",
+                    userId,
+                    ReferenceType.USER
+            );
+        } catch (Exception e) {
+            log.error("Error processing user.registered event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.POST_CREATED_QUEUE)
+    public void handlePostCreated(Object message) {
+        try {
+            String postId = extractString(message);
+            log.info("Received post.created event for postId: {}", postId);
+            // Post service sends just the post ID; broadcast notification handled at service level
+            notificationService.createNotification(
+                    "all",
+                    NotificationType.NEW_POST,
+                    "New Post",
+                    "A new post has been shared on the platform.",
+                    postId,
+                    ReferenceType.POST
+            );
+        } catch (Exception e) {
+            log.error("Error processing post.created event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.POST_LIKED_QUEUE)
+    public void handlePostLiked(Map<String, Object> message) {
+        try {
+            log.info("Received post.liked event: {}", message);
+            String postOwnerId = getString(message, "postOwnerId");
+            String userName = getString(message, "userName");
+            String postId = getString(message, "postId");
+
+            if (postOwnerId != null) {
+                notificationService.createNotification(
+                        postOwnerId,
+                        NotificationType.POST_LIKED,
+                        "Post Liked",
+                        userName + " liked your post.",
+                        postId,
+                        ReferenceType.POST
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error processing post.liked event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.POST_COMMENTED_QUEUE)
+    public void handlePostCommented(Map<String, Object> message) {
+        try {
+            log.info("Received post.commented event: {}", message);
+            String postOwnerId = getString(message, "postOwnerId");
+            String userName = getString(message, "userName");
+            String postId = getString(message, "postId");
+
+            if (postOwnerId != null) {
+                notificationService.createNotification(
+                        postOwnerId,
+                        NotificationType.POST_COMMENTED,
+                        "New Comment",
+                        userName + " commented on your post.",
+                        postId,
+                        ReferenceType.POST
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error processing post.commented event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.JOB_CREATED_QUEUE)
+    public void handleJobCreated(Map<String, Object> message) {
+        try {
+            log.info("Received job.created event: {}", message);
+            String title = getString(message, "title");
+            String jobId = getString(message, "jobId");
+
+            notificationService.createNotification(
+                    "all",
+                    NotificationType.JOB_CREATED,
+                    "New Job Opportunity",
+                    "New job opportunity: " + title,
+                    jobId,
+                    ReferenceType.JOB
+            );
+        } catch (Exception e) {
+            log.error("Error processing job.created event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.JOB_APPLIED_QUEUE)
+    public void handleJobApplied(Map<String, Object> message) {
+        try {
+            log.info("Received job.applied event: {}", message);
+            String employerId = getString(message, "employerId");
+            String userName = getString(message, "userName");
+            String jobId = getString(message, "jobId");
+            String jobTitle = getString(message, "jobTitle");
+
+            if (employerId != null) {
+                notificationService.createNotification(
+                        employerId,
+                        NotificationType.JOB_APPLICATION,
+                        "New Application",
+                        userName + " applied to your job: " + jobTitle,
+                        jobId,
+                        ReferenceType.JOB
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error processing job.applied event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.EVENT_CREATED_QUEUE)
+    public void handleEventCreated(Map<String, Object> message) {
+        try {
+            log.info("Received event.created event: {}", message);
+            String title = getString(message, "title");
+            String eventId = getString(message, "eventId");
+
+            notificationService.createNotification(
+                    "all",
+                    NotificationType.EVENT_CREATED,
+                    "New Event",
+                    "New event: " + title,
+                    eventId,
+                    ReferenceType.EVENT
+            );
+        } catch (Exception e) {
+            log.error("Error processing event.created event: {}", e.getMessage(), e);
+        }
+    }
+
+    @RabbitListener(queues = RabbitMQConfig.EVENT_RSVP_QUEUE)
+    public void handleEventRsvp(Map<String, Object> message) {
+        try {
+            log.info("Received event.rsvp event: {}", message);
+            String organizerName = getString(message, "organizerName");
+            String userName = getString(message, "userName");
+            String eventId = getString(message, "eventId");
+            String status = getString(message, "status");
+
+            if (organizerName != null && !userName.equals(organizerName)) {
+                notificationService.createNotification(
+                        organizerName,
+                        NotificationType.EVENT_RSVP,
+                        "New RSVP",
+                        userName + " RSVP'd (" + status + ") to your event.",
+                        eventId,
+                        ReferenceType.EVENT
+                );
+            }
+        } catch (Exception e) {
+            log.error("Error processing event.rsvp event: {}", e.getMessage(), e);
+        }
+    }
+
+    private String getString(Map<String, Object> map, String key) {
+        Object value = map.get(key);
+        return value != null ? value.toString() : null;
+    }
+
+    private String extractString(Object message) {
+        if (message instanceof String) {
+            return (String) message;
+        }
+        return message.toString();
+    }
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/model/Notification.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/model/Notification.java
@@ -1,0 +1,43 @@
+package com.decp.notification.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Document(collection = "notifications")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Notification {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String userId;
+
+    private NotificationType type;
+
+    private String title;
+
+    private String message;
+
+    private String referenceId;
+
+    private ReferenceType referenceType;
+
+    @Builder.Default
+    private boolean read = false;
+
+    private LocalDateTime createdAt;
+
+    @Indexed(expireAfter = "0s")
+    private LocalDateTime expiresAt;
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/model/NotificationType.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/model/NotificationType.java
@@ -1,0 +1,13 @@
+package com.decp.notification.model;
+
+public enum NotificationType {
+    JOB_APPLICATION,
+    JOB_CREATED,
+    NEW_POST,
+    POST_LIKED,
+    POST_COMMENTED,
+    EVENT_CREATED,
+    EVENT_RSVP,
+    USER_REGISTERED,
+    SYSTEM
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/model/ReferenceType.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/model/ReferenceType.java
@@ -1,0 +1,8 @@
+package com.decp.notification.model;
+
+public enum ReferenceType {
+    JOB,
+    POST,
+    EVENT,
+    USER
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/repository/NotificationRepository.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/repository/NotificationRepository.java
@@ -1,0 +1,15 @@
+package com.decp.notification.repository;
+
+import com.decp.notification.model.Notification;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends MongoRepository<Notification, String> {
+
+    List<Notification> findByUserIdOrderByCreatedAtDesc(String userId);
+
+    long countByUserIdAndReadFalse(String userId);
+
+    List<Notification> findByUserIdAndReadFalse(String userId);
+}

--- a/backend/notification-service/src/main/java/com/decp/notification/service/NotificationService.java
+++ b/backend/notification-service/src/main/java/com/decp/notification/service/NotificationService.java
@@ -1,0 +1,128 @@
+package com.decp.notification.service;
+
+import com.decp.notification.dto.NotificationResponse;
+import com.decp.notification.model.Notification;
+import com.decp.notification.model.NotificationType;
+import com.decp.notification.model.ReferenceType;
+import com.decp.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final StringRedisTemplate redisTemplate;
+
+    private static final String UNREAD_COUNT_KEY_PREFIX = "notifications:unread:";
+
+    public Notification createNotification(String userId, NotificationType type, String title,
+                                           String message, String referenceId, ReferenceType referenceType) {
+        Notification notification = Notification.builder()
+                .userId(userId)
+                .type(type)
+                .title(title)
+                .message(message)
+                .referenceId(referenceId)
+                .referenceType(referenceType)
+                .read(false)
+                .createdAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusDays(30))
+                .build();
+
+        Notification saved = notificationRepository.save(notification);
+        incrementUnreadCount(userId);
+        return saved;
+    }
+
+    public List<NotificationResponse> getUserNotifications(String userName) {
+        return notificationRepository.findByUserIdOrderByCreatedAtDesc(userName)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public NotificationResponse markAsRead(String id, String userName) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Notification not found with id: " + id));
+
+        if (!userName.equals(notification.getUserId())) {
+            throw new RuntimeException("Not authorized to modify this notification");
+        }
+
+        if (!notification.isRead()) {
+            notification.setRead(true);
+            notificationRepository.save(notification);
+            decrementUnreadCount(userName);
+        }
+
+        return toResponse(notification);
+    }
+
+    public void markAllAsRead(String userName) {
+        List<Notification> unread = notificationRepository.findByUserIdAndReadFalse(userName);
+        unread.forEach(n -> n.setRead(true));
+        notificationRepository.saveAll(unread);
+        resetUnreadCount(userName);
+    }
+
+    public long getUnreadCount(String userName) {
+        String cached = redisTemplate.opsForValue().get(UNREAD_COUNT_KEY_PREFIX + userName);
+        if (cached != null) {
+            return Long.parseLong(cached);
+        }
+        long count = notificationRepository.countByUserIdAndReadFalse(userName);
+        redisTemplate.opsForValue().set(UNREAD_COUNT_KEY_PREFIX + userName, String.valueOf(count));
+        return count;
+    }
+
+    public void deleteNotification(String id, String userName) {
+        Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Notification not found with id: " + id));
+
+        if (!userName.equals(notification.getUserId())) {
+            throw new RuntimeException("Not authorized to delete this notification");
+        }
+
+        if (!notification.isRead()) {
+            decrementUnreadCount(userName);
+        }
+
+        notificationRepository.delete(notification);
+    }
+
+    private void incrementUnreadCount(String userId) {
+        redisTemplate.opsForValue().increment(UNREAD_COUNT_KEY_PREFIX + userId);
+    }
+
+    private void decrementUnreadCount(String userId) {
+        String key = UNREAD_COUNT_KEY_PREFIX + userId;
+        String current = redisTemplate.opsForValue().get(key);
+        if (current != null && Long.parseLong(current) > 0) {
+            redisTemplate.opsForValue().decrement(key);
+        }
+    }
+
+    private void resetUnreadCount(String userId) {
+        redisTemplate.opsForValue().set(UNREAD_COUNT_KEY_PREFIX + userId, "0");
+    }
+
+    private NotificationResponse toResponse(Notification notification) {
+        return NotificationResponse.builder()
+                .id(notification.getId())
+                .userId(notification.getUserId())
+                .type(notification.getType())
+                .title(notification.getTitle())
+                .message(notification.getMessage())
+                .referenceId(notification.getReferenceId())
+                .referenceType(notification.getReferenceType())
+                .read(notification.isRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/notification-service/src/main/resources/application.yml
+++ b/backend/notification-service/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+server:
+  port: 8088
+
+spring:
+  application:
+    name: notification-service
+  data:
+    mongodb:
+      uri: ${SPRING_DATA_MONGODB_URI:mongodb://admin:admin1234@localhost:27018/decp_notifications?authSource=admin}
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
+  rabbitmq:
+    host: ${RABBITMQ_HOST:localhost}
+    port: ${RABBITMQ_PORT:5672}
+    username: ${RABBITMQ_USER:guest}
+    password: ${RABBITMQ_PASSWORD:guest}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -31,6 +31,7 @@
         <module>post-service</module>
         <module>job-service</module>
         <module>event-service</module>
+        <module>notification-service</module>
     </modules>
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,12 +46,16 @@ services:
       - SPRING_CLOUD_GATEWAY_ROUTES_2_URI=http://user-service:8082
       - SPRING_CLOUD_GATEWAY_ROUTES_3_URI=http://post-service:8083
       - SPRING_CLOUD_GATEWAY_ROUTES_4_URI=http://job-service:8084
+      - SPRING_CLOUD_GATEWAY_ROUTES_5_URI=http://event-service:8085
+      - SPRING_CLOUD_GATEWAY_ROUTES_6_URI=http://notification-service:8088
       - JWT_SECRET=${JWT_SECRET:-your-very-secure-and-long-secret-key-for-decp-project}
     depends_on:
       - auth-service
       - user-service
       - post-service
       - job-service
+      - event-service
+      - notification-service
 
   auth-service:
     build: ./backend/auth-service
@@ -101,6 +105,20 @@ services:
     depends_on:
       - postgres
       - rabbitmq
+
+  notification-service:
+    build: ./backend/notification-service
+    container_name: decp-notification-prod
+    ports:
+      - "8088:8088"
+    environment:
+      - SPRING_DATA_MONGODB_URI=mongodb://root:rootpassword@mongodb:27017/decp_notifications?authSource=admin
+      - SPRING_RABBITMQ_HOST=rabbitmq
+      - REDIS_HOST=redis
+    depends_on:
+      - mongodb
+      - rabbitmq
+      - redis
 
   # Frontend
   web-client:


### PR DESCRIPTION
- Create notification-service module with MongoDB + Redis + RabbitMQ
- Notification model with 30-day TTL auto-expiry via MongoDB indexes
- Redis caching for unread notification counts (increment/decrement/reset)
- 8 RabbitMQ listeners consuming events:
  * user.registered → USER_REGISTERED notifications
  * post.created, post.liked, post.commented → POST notifications
  * job.created, job.applied → JOB notifications
  * event.created, event.rsvp → EVENT notifications
- 5 REST endpoints (GET notifications, PUT read/read-all, GET unread-count, DELETE)
- Owner-only access enforced via X-User-Name header from JWT gateway filter
- Global exception handler with proper HTTP status mapping
- Add notification-service to parent pom.xml modules list
- Add /api/notifications/** route to API Gateway with JWT filter
- Add notification-service container to docker-compose.prod.yml
- Maven build successful: All 12 classes compiled, JAR packaged