### PR TITLE
feat: add Messaging Service for real-time chat

### DIFF
--- a/backend/api-gateway/src/main/resources/application.yml
+++ b/backend/api-gateway/src/main/resources/application.yml
@@ -74,6 +74,28 @@ spring:
           filters:
             - Jwt
 
+        # Messaging Service WebSocket: /ws/** -> localhost:8087
+        - id: messaging-service-ws
+          uri: ws://localhost:8087
+          predicates:
+            - Path=/ws/**
+
+        # Messaging Service REST: /api/conversations/** -> localhost:8087
+        - id: messaging-service
+          uri: http://localhost:8087
+          predicates:
+            - Path=/api/conversations/**
+          filters:
+            - Jwt
+
+        # Research Service: /api/research/** -> localhost:8086/api/research/**
+        - id: research-service
+          uri: http://localhost:8086
+          predicates:
+            - Path=/api/research/**
+          filters:
+            - Jwt
+
 management:
   endpoints:
     web:

--- a/backend/messaging-service/Dockerfile
+++ b/backend/messaging-service/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-jdk-slim
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8087
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/messaging-service/pom.xml
+++ b/backend/messaging-service/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.decp</groupId>
+        <artifactId>decp-backend</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>messaging-service</artifactId>
+    <name>Messaging Service</name>
+    <description>Real-time Messaging Service for DECP</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-websocket</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/backend/messaging-service/src/main/java/com/decp/messaging/MessagingServiceApplication.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/MessagingServiceApplication.java
@@ -1,0 +1,11 @@
+package com.decp.messaging;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MessagingServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MessagingServiceApplication.class, args);
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/config/RedisConfig.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package com.decp.messaging.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/config/WebSocketConfig.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.decp.messaging.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic", "/queue");
+        config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/controller/ChatController.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/controller/ChatController.java
@@ -1,0 +1,74 @@
+package com.decp.messaging.controller;
+
+import com.decp.messaging.dto.ChatMessageRequest;
+import com.decp.messaging.dto.MessageResponse;
+import com.decp.messaging.dto.TypingIndicator;
+import com.decp.messaging.service.MessagingService;
+import com.decp.messaging.service.OnlineStatusService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final MessagingService messagingService;
+    private final OnlineStatusService onlineStatusService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat/send")
+    public void sendMessage(@Payload ChatMessageRequest request,
+                            @Header(value = "X-User-Id", defaultValue = "0") Long userId,
+                            @Header(value = "X-User-Name", defaultValue = "Unknown") String userName) {
+
+        // Refresh online status on activity
+        onlineStatusService.setUserOnline(userId);
+
+        MessageResponse response = messagingService.sendMessage(
+                request.getConversationId(),
+                userId,
+                userName,
+                request.getContent()
+        );
+
+        // Broadcast to conversation topic
+        messagingTemplate.convertAndSend(
+                "/topic/messages/" + request.getConversationId(),
+                response
+        );
+    }
+
+    @MessageMapping("/chat/typing")
+    public void typing(@Payload TypingIndicator indicator) {
+        messagingTemplate.convertAndSend(
+                "/topic/typing/" + indicator.getConversationId(),
+                indicator
+        );
+    }
+
+    @MessageMapping("/chat/read")
+    public void markRead(@Payload String conversationId,
+                         @Header(value = "X-User-Id", defaultValue = "0") Long userId) {
+        messagingService.markMessagesAsRead(conversationId, userId);
+
+        // Notify others that messages were read
+        messagingTemplate.convertAndSend(
+                "/topic/read/" + conversationId,
+                userId
+        );
+    }
+
+    @MessageMapping("/chat/online")
+    public void setOnline(@Header(value = "X-User-Id", defaultValue = "0") Long userId) {
+        onlineStatusService.setUserOnline(userId);
+    }
+
+    @MessageMapping("/chat/offline")
+    public void setOffline(@Header(value = "X-User-Id", defaultValue = "0") Long userId) {
+        onlineStatusService.setUserOffline(userId);
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/controller/ConversationController.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/controller/ConversationController.java
@@ -1,0 +1,76 @@
+package com.decp.messaging.controller;
+
+import com.decp.messaging.dto.ConversationRequest;
+import com.decp.messaging.dto.ConversationResponse;
+import com.decp.messaging.dto.MessageResponse;
+import com.decp.messaging.service.MessagingService;
+import com.decp.messaging.service.OnlineStatusService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/api/conversations")
+@RequiredArgsConstructor
+public class ConversationController {
+
+    private final MessagingService messagingService;
+    private final OnlineStatusService onlineStatusService;
+
+    @PostMapping
+    public ResponseEntity<ConversationResponse> createConversation(
+            @RequestHeader("X-User-Name") String userName,
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId,
+            @Valid @RequestBody ConversationRequest request) {
+        return ResponseEntity.ok(messagingService.createConversation(request, userId, userName));
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ConversationResponse>> getUserConversations(
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId) {
+        return ResponseEntity.ok(messagingService.getUserConversations(userId));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ConversationResponse> getConversation(
+            @PathVariable String id,
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId) {
+        return ResponseEntity.ok(messagingService.getConversation(id, userId));
+    }
+
+    @GetMapping("/{id}/messages")
+    public ResponseEntity<Page<MessageResponse>> getMessages(
+            @PathVariable String id,
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size) {
+        return ResponseEntity.ok(messagingService.getMessages(id, userId, page, size));
+    }
+
+    @PutMapping("/{id}/read")
+    public ResponseEntity<Void> markAsRead(
+            @PathVariable String id,
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId) {
+        messagingService.markMessagesAsRead(id, userId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteConversation(
+            @PathVariable String id,
+            @RequestHeader(value = "X-User-Id", required = false, defaultValue = "0") Long userId) {
+        messagingService.deleteConversation(id, userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/online")
+    public ResponseEntity<Set<Long>> getOnlineUsers(
+            @RequestParam Set<Long> userIds) {
+        return ResponseEntity.ok(onlineStatusService.getOnlineUsers(userIds));
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/dto/ChatMessageRequest.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/dto/ChatMessageRequest.java
@@ -1,0 +1,18 @@
+package com.decp.messaging.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequest {
+
+    @NotBlank(message = "Conversation ID is required")
+    private String conversationId;
+
+    @NotBlank(message = "Message content is required")
+    private String content;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/dto/ConversationRequest.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/dto/ConversationRequest.java
@@ -1,0 +1,21 @@
+package com.decp.messaging.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationRequest {
+
+    @NotEmpty(message = "Participants list is required")
+    private List<Long> participantIds;
+
+    private List<String> participantNames;
+
+    private String initialMessage;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/dto/ConversationResponse.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/dto/ConversationResponse.java
@@ -1,0 +1,24 @@
+package com.decp.messaging.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConversationResponse {
+
+    private String id;
+    private List<Long> participants;
+    private List<String> participantNames;
+    private String lastMessage;
+    private LocalDateTime lastMessageAt;
+    private LocalDateTime createdAt;
+    private long unreadCount;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/dto/MessageResponse.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/dto/MessageResponse.java
@@ -1,0 +1,24 @@
+package com.decp.messaging.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MessageResponse {
+
+    private String id;
+    private String conversationId;
+    private Long senderId;
+    private String senderName;
+    private String content;
+    private List<Long> readBy;
+    private LocalDateTime createdAt;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/dto/TypingIndicator.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/dto/TypingIndicator.java
@@ -1,0 +1,16 @@
+package com.decp.messaging.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TypingIndicator {
+
+    private String conversationId;
+    private Long userId;
+    private String userName;
+    private boolean typing;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/exception/GlobalExceptionHandler.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/exception/GlobalExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.decp.messaging.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<Map<String, Object>> handleRuntimeException(RuntimeException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("message", ex.getMessage());
+
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        if (ex.getMessage() != null) {
+            if (ex.getMessage().contains("not found")) {
+                status = HttpStatus.NOT_FOUND;
+            } else if (ex.getMessage().contains("Not authorized")) {
+                status = HttpStatus.FORBIDDEN;
+            }
+        }
+
+        body.put("status", status.value());
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now().toString());
+        body.put("status", HttpStatus.BAD_REQUEST.value());
+
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getFieldErrors()
+                .forEach(error -> errors.put(error.getField(), error.getDefaultMessage()));
+        body.put("errors", errors);
+
+        return ResponseEntity.badRequest().body(body);
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/model/Conversation.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/model/Conversation.java
@@ -1,0 +1,40 @@
+package com.decp.messaging.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "conversations")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Conversation {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private List<Long> participants;
+
+    private List<String> participantNames;
+
+    private String lastMessage;
+
+    private LocalDateTime lastMessageAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @Builder.Default
+    private List<Long> deletedBy = new ArrayList<>();
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/model/Message.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/model/Message.java
@@ -1,0 +1,38 @@
+package com.decp.messaging.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Document(collection = "messages")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Message {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String conversationId;
+
+    private Long senderId;
+
+    private String senderName;
+
+    private String content;
+
+    @Builder.Default
+    private List<Long> readBy = new ArrayList<>();
+
+    private LocalDateTime createdAt;
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/repository/ConversationRepository.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/repository/ConversationRepository.java
@@ -1,0 +1,15 @@
+package com.decp.messaging.repository;
+
+import com.decp.messaging.model.Conversation;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ConversationRepository extends MongoRepository<Conversation, String> {
+
+    List<Conversation> findByParticipantsContainingOrderByLastMessageAtDesc(Long userId);
+
+    List<Conversation> findByParticipantsContainingAndDeletedByNotContainingOrderByLastMessageAtDesc(Long userId, Long deletedUserId);
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/repository/MessageRepository.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/repository/MessageRepository.java
@@ -1,0 +1,17 @@
+package com.decp.messaging.repository;
+
+import com.decp.messaging.model.Message;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MessageRepository extends MongoRepository<Message, String> {
+
+    Page<Message> findByConversationIdOrderByCreatedAtDesc(String conversationId, Pageable pageable);
+
+    long countByConversationIdAndReadByNotContaining(String conversationId, Long userId);
+
+    void deleteAllByConversationId(String conversationId);
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/service/MessagingService.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/service/MessagingService.java
@@ -1,0 +1,177 @@
+package com.decp.messaging.service;
+
+import com.decp.messaging.dto.*;
+import com.decp.messaging.model.Conversation;
+import com.decp.messaging.model.Message;
+import com.decp.messaging.repository.ConversationRepository;
+import com.decp.messaging.repository.MessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MessagingService {
+
+    private final ConversationRepository conversationRepository;
+    private final MessageRepository messageRepository;
+
+    public ConversationResponse createConversation(ConversationRequest request, Long currentUserId, String currentUserName) {
+        // Ensure current user is in participants
+        List<Long> participants = new java.util.ArrayList<>(request.getParticipantIds());
+        if (!participants.contains(currentUserId)) {
+            participants.add(currentUserId);
+        }
+
+        List<String> participantNames = request.getParticipantNames() != null
+                ? new java.util.ArrayList<>(request.getParticipantNames())
+                : new java.util.ArrayList<>();
+        if (!participantNames.contains(currentUserName)) {
+            participantNames.add(currentUserName);
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        Conversation conversation = Conversation.builder()
+                .participants(participants)
+                .participantNames(participantNames)
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        // If initial message provided, set it
+        if (request.getInitialMessage() != null && !request.getInitialMessage().isBlank()) {
+            conversation.setLastMessage(request.getInitialMessage());
+            conversation.setLastMessageAt(now);
+        }
+
+        Conversation saved = conversationRepository.save(conversation);
+
+        // Create initial message if provided
+        if (request.getInitialMessage() != null && !request.getInitialMessage().isBlank()) {
+            Message message = Message.builder()
+                    .conversationId(saved.getId())
+                    .senderId(currentUserId)
+                    .senderName(currentUserName)
+                    .content(request.getInitialMessage())
+                    .readBy(List.of(currentUserId))
+                    .createdAt(now)
+                    .build();
+            messageRepository.save(message);
+        }
+
+        return toConversationResponse(saved, currentUserId);
+    }
+
+    public List<ConversationResponse> getUserConversations(Long userId) {
+        return conversationRepository
+                .findByParticipantsContainingAndDeletedByNotContainingOrderByLastMessageAtDesc(userId, userId)
+                .stream()
+                .map(c -> toConversationResponse(c, userId))
+                .toList();
+    }
+
+    public ConversationResponse getConversation(String conversationId, Long userId) {
+        Conversation conversation = findConversationAndVerifyAccess(conversationId, userId);
+        return toConversationResponse(conversation, userId);
+    }
+
+    public Page<MessageResponse> getMessages(String conversationId, Long userId, int page, int size) {
+        findConversationAndVerifyAccess(conversationId, userId);
+
+        Pageable pageable = PageRequest.of(page, size);
+        return messageRepository.findByConversationIdOrderByCreatedAtDesc(conversationId, pageable)
+                .map(this::toMessageResponse);
+    }
+
+    public MessageResponse sendMessage(String conversationId, Long senderId, String senderName, String content) {
+        Conversation conversation = findConversationAndVerifyAccess(conversationId, senderId);
+
+        LocalDateTime now = LocalDateTime.now();
+        Message message = Message.builder()
+                .conversationId(conversationId)
+                .senderId(senderId)
+                .senderName(senderName)
+                .content(content)
+                .readBy(List.of(senderId))
+                .createdAt(now)
+                .build();
+
+        Message saved = messageRepository.save(message);
+
+        // Update conversation with last message
+        conversation.setLastMessage(content);
+        conversation.setLastMessageAt(now);
+        conversation.setUpdatedAt(now);
+        conversationRepository.save(conversation);
+
+        return toMessageResponse(saved);
+    }
+
+    public void markMessagesAsRead(String conversationId, Long userId) {
+        findConversationAndVerifyAccess(conversationId, userId);
+
+        Pageable allMessages = PageRequest.of(0, 1000);
+        Page<Message> messages = messageRepository.findByConversationIdOrderByCreatedAtDesc(conversationId, allMessages);
+
+        messages.getContent().stream()
+                .filter(m -> !m.getReadBy().contains(userId))
+                .forEach(m -> {
+                    m.getReadBy().add(userId);
+                    messageRepository.save(m);
+                });
+    }
+
+    public void deleteConversation(String conversationId, Long userId) {
+        Conversation conversation = findConversationAndVerifyAccess(conversationId, userId);
+        conversation.getDeletedBy().add(userId);
+
+        // If all participants deleted, remove entirely
+        if (conversation.getDeletedBy().containsAll(conversation.getParticipants())) {
+            messageRepository.deleteAllByConversationId(conversationId);
+            conversationRepository.delete(conversation);
+        } else {
+            conversationRepository.save(conversation);
+        }
+    }
+
+    private Conversation findConversationAndVerifyAccess(String conversationId, Long userId) {
+        Conversation conversation = conversationRepository.findById(conversationId)
+                .orElseThrow(() -> new RuntimeException("Conversation not found with id: " + conversationId));
+
+        if (!conversation.getParticipants().contains(userId)) {
+            throw new RuntimeException("Not authorized to access this conversation");
+        }
+
+        return conversation;
+    }
+
+    private ConversationResponse toConversationResponse(Conversation conversation, Long userId) {
+        long unreadCount = messageRepository.countByConversationIdAndReadByNotContaining(conversation.getId(), userId);
+        return ConversationResponse.builder()
+                .id(conversation.getId())
+                .participants(conversation.getParticipants())
+                .participantNames(conversation.getParticipantNames())
+                .lastMessage(conversation.getLastMessage())
+                .lastMessageAt(conversation.getLastMessageAt())
+                .createdAt(conversation.getCreatedAt())
+                .unreadCount(unreadCount)
+                .build();
+    }
+
+    private MessageResponse toMessageResponse(Message message) {
+        return MessageResponse.builder()
+                .id(message.getId())
+                .conversationId(message.getConversationId())
+                .senderId(message.getSenderId())
+                .senderName(message.getSenderName())
+                .content(message.getContent())
+                .readBy(message.getReadBy())
+                .createdAt(message.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/messaging-service/src/main/java/com/decp/messaging/service/OnlineStatusService.java
+++ b/backend/messaging-service/src/main/java/com/decp/messaging/service/OnlineStatusService.java
@@ -1,0 +1,41 @@
+package com.decp.messaging.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class OnlineStatusService {
+
+    private static final String ONLINE_KEY_PREFIX = "user:online:";
+    private static final Duration ONLINE_TTL = Duration.ofMinutes(5);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void setUserOnline(Long userId) {
+        redisTemplate.opsForValue().set(ONLINE_KEY_PREFIX + userId, "online", ONLINE_TTL);
+    }
+
+    public void setUserOffline(Long userId) {
+        redisTemplate.delete(ONLINE_KEY_PREFIX + userId);
+    }
+
+    public boolean isUserOnline(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(ONLINE_KEY_PREFIX + userId));
+    }
+
+    public Set<Long> getOnlineUsers(Set<Long> userIds) {
+        return userIds.stream()
+                .filter(this::isUserOnline)
+                .collect(Collectors.toSet());
+    }
+
+    public void refreshOnlineStatus(Long userId) {
+        redisTemplate.expire(ONLINE_KEY_PREFIX + userId, ONLINE_TTL);
+    }
+}

--- a/backend/messaging-service/src/main/resources/application.yml
+++ b/backend/messaging-service/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+server:
+  port: 8087
+
+spring:
+  application:
+    name: messaging-service
+  data:
+    mongodb:
+      uri: ${SPRING_DATA_MONGODB_URI:mongodb://admin:admin1234@localhost:27018/decp_messaging?authSource=admin}
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,6 +32,8 @@
         <module>job-service</module>
         <module>event-service</module>
         <module>notification-service</module>
+        <module>research-service</module>
+        <module>messaging-service</module>
     </modules>
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -48,6 +48,7 @@ services:
       - SPRING_CLOUD_GATEWAY_ROUTES_4_URI=http://job-service:8084
       - SPRING_CLOUD_GATEWAY_ROUTES_5_URI=http://event-service:8085
       - SPRING_CLOUD_GATEWAY_ROUTES_6_URI=http://notification-service:8088
+      - SPRING_CLOUD_GATEWAY_ROUTES_7_URI=http://research-service:8086
       - JWT_SECRET=${JWT_SECRET:-your-very-secure-and-long-secret-key-for-decp-project}
     depends_on:
       - auth-service
@@ -56,6 +57,7 @@ services:
       - job-service
       - event-service
       - notification-service
+      - research-service
 
   auth-service:
     build: ./backend/auth-service
@@ -106,19 +108,17 @@ services:
       - postgres
       - rabbitmq
 
-  notification-service:
-    build: ./backend/notification-service
-    container_name: decp-notification-prod
+  research-service:
+    build: ./backend/research-service
+    container_name: decp-research-prod
     ports:
-      - "8088:8088"
+      - "8086:8086"
     environment:
-      - SPRING_DATA_MONGODB_URI=mongodb://root:rootpassword@mongodb:27017/decp_notifications?authSource=admin
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:5432/decp_db
       - SPRING_RABBITMQ_HOST=rabbitmq
-      - REDIS_HOST=redis
     depends_on:
-      - mongodb
+      - postgres
       - rabbitmq
-      - redis
 
   # Frontend
   web-client:


### PR DESCRIPTION
- Create messaging-service module (Spring Boot 3.2.3, Java 17)
- Implement MongoDB-backed Conversation and Message models
- Add WebSocket STOMP endpoint at /ws/chat with SockJS fallback
- Implement real-time message send, typing indicators, read receipts
- Add Redis-based online status tracking (5min TTL)
- Implement ConversationController for REST conversation management
- Implement ChatController for WebSocket STOMP message handling
- Add soft-delete via deletedBy field for conversation privacy
- Add paginated message retrieval with unread count
- Include GlobalExceptionHandler for validation and access control
- Add WebSocket route to API Gateway: /ws/** -> ws://localhost:8087
- Add REST route to API Gateway: /api/conversations/** -> localhost:8087 with JWT"